### PR TITLE
Кэш промпта и метрики расхода на модель

### DIFF
--- a/app/application/ports/observability_port.py
+++ b/app/application/ports/observability_port.py
@@ -13,6 +13,15 @@ class SkipReason(StrEnum):
     PARSE_FAILED = "parse_failed"
 
 
+class TokenKind(StrEnum):
+    """Как провайдер посчитал токены: обычный вход дороже чтения из кэша."""
+
+    INPUT = "input"
+    OUTPUT = "output"
+    CACHE_READ = "cache_read"
+    CACHE_WRITE = "cache_write"
+
+
 class Feature(StrEnum):
     """Что нажал пользователь. Метка одна на все фичи, чтобы не плодить метрики."""
 
@@ -44,3 +53,7 @@ class IObservabilityService(Protocol):
     def observe_feature_used(self, feature: Feature, count: int = 1) -> None: ...
 
     def observe_match_rejected(self, reason: str, count: int = 1) -> None: ...
+
+    def observe_llm_tokens(self, kind: TokenKind, tokens: int) -> None: ...
+
+    def observe_llm_cost(self, model: str, micro_usd: int) -> None: ...

--- a/app/bootstrap/metrics_sync.py
+++ b/app/bootstrap/metrics_sync.py
@@ -11,6 +11,8 @@ from app.infrastructure.observability.metrics import (
     DISPATCHED_BY_SKILL,
     DISPATCHED_BY_SPECIALIZATION,
     FEATURE_USED,
+    LLM_COST_MICRO_USD,
+    LLM_TOKENS,
     MATCH_REJECTED,
     MESSAGES_SKIPPED,
     USERS_TOTAL,
@@ -21,6 +23,8 @@ from app.infrastructure.observability.metrics import (
 )
 from app.infrastructure.observability.service import (
     COUNTER_FEATURE_USED,
+    COUNTER_LLM_COST_MICRO,
+    COUNTER_LLM_TOKENS,
     COUNTER_MATCH_REJECTED,
     COUNTER_MESSAGES_SKIPPED,
 )
@@ -33,6 +37,8 @@ _COUNTER_GAUGES = {
     COUNTER_MESSAGES_SKIPPED: (MESSAGES_SKIPPED, "reason"),
     COUNTER_FEATURE_USED: (FEATURE_USED, "feature"),
     COUNTER_MATCH_REJECTED: (MATCH_REJECTED, "reason"),
+    COUNTER_LLM_TOKENS: (LLM_TOKENS, "kind"),
+    COUNTER_LLM_COST_MICRO: (LLM_COST_MICRO_USD, "model"),
 }
 
 

--- a/app/infrastructure/extractors/vacancy_extractor.py
+++ b/app/infrastructure/extractors/vacancy_extractor.py
@@ -1,5 +1,7 @@
 import re
 
+from pydantic_ai import CachePoint
+
 from app.application.dto import OutVacancyParse
 from app.application.ports.llm_port import IVacancyLLMExtractor
 from app.core.logger import get_app_logger
@@ -99,9 +101,13 @@ class GoogleVacancyLLMExtractor(IVacancyLLMExtractor):
         result = await run_with_llm_retry(
             "vacancy_parse",
             lambda: self._agent.run(
-                user_prompt=(
-                    f"Проанализируй текст и сначала определи, является ли он вакансией:\n{text}"
-                ),
+                # Метка стоит первой: под кэш уходит всё, что до неё, —
+                # системный промпт и схема ответа. Текст вакансии каждый раз
+                # новый, кэшировать его нельзя, иначе попаданий не будет.
+                user_prompt=[
+                    CachePoint(),
+                    f"Проанализируй текст и сначала определи, является ли он вакансией:\n{text}",
+                ],
                 metadata={"pipeline": "vacancy_ingest"},
             ),
         )

--- a/app/infrastructure/llm_runtime.py
+++ b/app/infrastructure/llm_runtime.py
@@ -2,9 +2,13 @@ import asyncio
 from collections.abc import Awaitable, Callable
 
 from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.run import AgentRunResult
 
+from app.application.ports.observability_port import TokenKind
 from app.core.logger import get_app_logger
+from app.infrastructure.observability.current import observe_llm_cost, observe_llm_tokens
 from app.infrastructure.observability.metrics import LLM_ERRORS_TOTAL
+from app.infrastructure.observability.pricing import cost_micro_usd
 
 logger = get_app_logger(__name__)
 
@@ -23,7 +27,9 @@ async def run_with_llm_retry[T](
 ) -> T:
     for attempt in range(1, _RETRY_ATTEMPTS + 1):
         try:
-            return await runner()
+            result = await runner()
+            _record_usage(result)
+            return result
         except ModelHTTPError as exc:
             LLM_ERRORS_TOTAL.labels(
                 operation=operation_name,
@@ -64,3 +70,35 @@ async def run_with_llm_retry[T](
             raise
 
     raise TemporaryLLMUnavailableError(f"LLM temporarily unavailable during {operation_name}")
+
+
+def _record_usage(result: object) -> None:
+    """Считает расход по факту ответа: провайдер сам сообщает, что попало в кэш.
+
+    Ошибка учёта не должна ронять разбор, поэтому всё внутри try.
+    """
+    if not isinstance(result, AgentRunResult):
+        return
+    try:
+        usage = result.usage()
+        model = getattr(result.response, "model_name", None) or "unknown"
+        counts = {
+            TokenKind.INPUT: usage.input_tokens,
+            TokenKind.OUTPUT: usage.output_tokens,
+            TokenKind.CACHE_READ: usage.cache_read_tokens,
+            TokenKind.CACHE_WRITE: usage.cache_write_tokens,
+        }
+        for kind, tokens in counts.items():
+            observe_llm_tokens(kind, int(tokens or 0))
+        observe_llm_cost(
+            model,
+            cost_micro_usd(
+                model,
+                input_tokens=int(usage.input_tokens or 0),
+                output_tokens=int(usage.output_tokens or 0),
+                cache_read_tokens=int(usage.cache_read_tokens or 0),
+                cache_write_tokens=int(usage.cache_write_tokens or 0),
+            ),
+        )
+    except Exception:
+        logger.debug("Failed to record LLM usage", exc_info=True)

--- a/app/infrastructure/observability/__init__.py
+++ b/app/infrastructure/observability/__init__.py
@@ -4,7 +4,12 @@ from .bootstrap import (
     init_logfire,
     init_metrics_server,
 )
-from .current import observe_feature, set_observability_service
+from .current import (
+    observe_feature,
+    observe_llm_cost,
+    observe_llm_tokens,
+    set_observability_service,
+)
 from .service import NoOpObservabilityService, PrometheusObservabilityService
 
 __all__ = [
@@ -12,6 +17,8 @@ __all__ = [
     "PrometheusObservabilityService",
     "build_counter_store",
     "observe_feature",
+    "observe_llm_cost",
+    "observe_llm_tokens",
     "set_observability_service",
     "build_observability_service",
     "init_logfire",

--- a/app/infrastructure/observability/current.py
+++ b/app/infrastructure/observability/current.py
@@ -8,6 +8,7 @@
 from app.application.ports.observability_port import (
     Feature,
     IObservabilityService,
+    TokenKind,
 )
 
 _service: IObservabilityService | None = None
@@ -22,3 +23,13 @@ def observe_feature(feature: Feature, count: int = 1) -> None:
     """Тихо ничего не делает, пока сервис не собран — например, в тестах."""
     if _service is not None:
         _service.observe_feature_used(feature, count)
+
+
+def observe_llm_tokens(kind: TokenKind, tokens: int) -> None:
+    if _service is not None:
+        _service.observe_llm_tokens(kind, tokens)
+
+
+def observe_llm_cost(model: str, micro_usd: int) -> None:
+    if _service is not None:
+        _service.observe_llm_cost(model, micro_usd)

--- a/app/infrastructure/observability/metrics.py
+++ b/app/infrastructure/observability/metrics.py
@@ -119,3 +119,16 @@ def _current_process_rss_bytes() -> float:
 
 
 PROCESS_RSS_BYTES.set_function(_current_process_rss_bytes)
+
+
+LLM_TOKENS = Gauge(
+    "job_monitor_llm_tokens",
+    "Токены, потраченные моделью, накопительно по видам",
+    ["kind"],
+)
+
+LLM_COST_MICRO_USD = Gauge(
+    "job_monitor_llm_cost_micro_usd",
+    "Накопленный расход на модель в микродолларах",
+    ["model"],
+)

--- a/app/infrastructure/observability/pricing.py
+++ b/app/infrastructure/observability/pricing.py
@@ -1,0 +1,71 @@
+"""Перевод токенов в деньги.
+
+Цены за миллион токенов, каталог OpenRouter. Живут в коде, а не в дашборде:
+иначе стоимость считается в двух местах и расходится при смене модели.
+"""
+
+from dataclasses import dataclass
+
+from app.core.logger import get_app_logger
+
+logger = get_app_logger(__name__)
+
+MICRO_PER_USD = 1_000_000
+TOKENS_PER_UNIT = 1_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class ModelPrice:
+    """Доллары за миллион токенов."""
+
+    input: float
+    output: float
+    cache_read: float
+    cache_write: float
+
+
+# Запись в кэш у Gemini считается как вход плюс хранение за 5 минут:
+# 0.30 + 0.0833 * (5 / 60) ≈ 0.3069. У OpenAI запись бесплатна.
+PRICES: dict[str, ModelPrice] = {
+    "google/gemini-2.5-flash": ModelPrice(0.30, 2.50, 0.03, 0.3069),
+    "google/gemini-2.5-flash-lite": ModelPrice(0.10, 0.40, 0.01, 0.1069),
+    "openai/gpt-5-nano": ModelPrice(0.05, 0.40, 0.005, 0.05),
+    "openai/gpt-4.1-nano": ModelPrice(0.10, 0.40, 0.025, 0.10),
+    "qwen/qwen3.7-flash": ModelPrice(0.03, 0.13, 0.006, 0.03),
+}
+
+_unknown_reported: set[str] = set()
+
+
+def price_for(model: str) -> ModelPrice | None:
+    price = PRICES.get(model)
+    if price is None and model not in _unknown_reported:
+        _unknown_reported.add(model)
+        logger.warning("No price for model %s; cost metric will stay at zero", model)
+    return price
+
+
+def cost_micro_usd(
+    model: str,
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> int:
+    """Стоимость вызова в микродолларах.
+
+    Целое: счётчики в metric_counter хранят int, а доли цента при сложении
+    миллионов токенов теряться не должны.
+    """
+    price = price_for(model)
+    if price is None:
+        return 0
+
+    usd = (
+        input_tokens * price.input
+        + output_tokens * price.output
+        + cache_read_tokens * price.cache_read
+        + cache_write_tokens * price.cache_write
+    ) / TOKENS_PER_UNIT
+    return round(usd * MICRO_PER_USD)

--- a/app/infrastructure/observability/service.py
+++ b/app/infrastructure/observability/service.py
@@ -1,4 +1,9 @@
-from app.application.ports.observability_port import Feature, IObservabilityService, SkipReason
+from app.application.ports.observability_port import (
+    Feature,
+    IObservabilityService,
+    SkipReason,
+    TokenKind,
+)
 from app.infrastructure.observability.counter_store import PersistentCounterStore
 from app.infrastructure.observability.metrics import (
     ACTIVE_USERS_TOTAL,
@@ -14,6 +19,8 @@ from app.infrastructure.observability.metrics import (
 COUNTER_MESSAGES_SKIPPED = "messages_skipped"
 COUNTER_FEATURE_USED = "feature_used"
 COUNTER_MATCH_REJECTED = "match_rejected"
+COUNTER_LLM_TOKENS = "llm_tokens"
+COUNTER_LLM_COST_MICRO = "llm_cost_micro"
 
 
 class PrometheusObservabilityService(IObservabilityService):
@@ -31,6 +38,14 @@ class PrometheusObservabilityService(IObservabilityService):
     def observe_match_rejected(self, reason: str, count: int = 1) -> None:
         if self._counters is not None:
             self._counters.increment(COUNTER_MATCH_REJECTED, reason, count)
+
+    def observe_llm_tokens(self, kind: TokenKind, tokens: int) -> None:
+        if self._counters is not None and tokens > 0:
+            self._counters.increment(COUNTER_LLM_TOKENS, kind.value, tokens)
+
+    def observe_llm_cost(self, model: str, micro_usd: int) -> None:
+        if self._counters is not None and micro_usd > 0:
+            self._counters.increment(COUNTER_LLM_COST_MICRO, model, micro_usd)
 
     def observe_vacancy_collected(self, count: int = 1) -> None:
         VACANCIES_COLLECTED_TOTAL.inc(count)
@@ -72,4 +87,10 @@ class NoOpObservabilityService(IObservabilityService):
         return None
 
     def observe_users_snapshot(self, total_users: int, active_users: int) -> None:
+        return None
+
+    def observe_llm_tokens(self, kind: TokenKind, tokens: int) -> None:
+        return None
+
+    def observe_llm_cost(self, model: str, micro_usd: int) -> None:
         return None

--- a/grafana/dashboards/pipeline_overview.json
+++ b/grafana/dashboards/pipeline_overview.json
@@ -527,6 +527,297 @@
       ],
       "title": "По навыкам",
       "type": "barchart"
+    },
+    {
+      "collapsed": false,
+      "id": 27,
+      "type": "row",
+      "title": "Расходы на модель",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "panels": []
+    },
+    {
+      "datasource": null,
+      "id": 28,
+      "title": "Потрачено всего",
+      "type": "stat",
+      "description": "Накопительно с первого запуска счётчиков.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 54
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(job_monitor_llm_cost_micro_usd) / 1e6",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": null,
+      "id": 29,
+      "title": "За последние сутки",
+      "type": "stat",
+      "description": "delta, а не increase: метрика — gauge, restore из БД.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 54
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(delta(job_monitor_llm_cost_micro_usd[24h])) / 1e6",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": null,
+      "id": 30,
+      "title": "Попаданий в кэш",
+      "type": "stat",
+      "description": "Ниже 2.5% кэш не окупается: запись дороже обычного входа на 2%.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 54
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(job_monitor_llm_tokens{kind=\"cache_read\"}) / clamp_min(sum(job_monitor_llm_tokens{kind=~\"cache_read|cache_write\"}), 1) * 100",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": null,
+      "id": 31,
+      "title": "Токенов всего",
+      "type": "stat",
+      "description": "Вход, выход, чтение и запись кэша вместе.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 54
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(job_monitor_llm_tokens)",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": null,
+      "id": 32,
+      "title": "Расход за интервал",
+      "type": "timeseries",
+      "description": "Во что обошёлся разбор сообщений за окно графика.",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(delta(job_monitor_llm_cost_micro_usd[$__rate_interval])) / 1e6",
+          "legendFormat": "$",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": null,
+      "id": 33,
+      "title": "Токены по видам",
+      "type": "timeseries",
+      "description": "cache_read вместо input — это и есть работающий кэш.",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 67
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (kind) (delta(job_monitor_llm_tokens[$__rate_interval]))",
+          "legendFormat": "{{kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/tests/unit/infrastructure/test_dashboards.py
+++ b/tests/unit/infrastructure/test_dashboards.py
@@ -71,6 +71,8 @@ def test_gauges_are_not_wrapped_in_increase(path: Path) -> None:
         "job_monitor_messages_skipped",
         "job_monitor_match_rejected",
         "job_monitor_dispatched_by",
+        "job_monitor_llm_tokens",
+        "job_monitor_llm_cost_micro_usd",
     )
 
     for expr in _expressions(path):

--- a/tests/unit/infrastructure/test_llm_cost.py
+++ b/tests/unit/infrastructure/test_llm_cost.py
@@ -1,0 +1,118 @@
+"""Учёт расхода на модель и метка кэша."""
+
+import pytest
+from pydantic_ai import CachePoint
+
+from app.application.ports.observability_port import TokenKind
+from app.infrastructure.observability import pricing
+from app.infrastructure.observability.pricing import PRICES, cost_micro_usd
+from app.infrastructure.observability.service import (
+    COUNTER_LLM_COST_MICRO,
+    COUNTER_LLM_TOKENS,
+    PrometheusObservabilityService,
+)
+
+MODEL = "google/gemini-2.5-flash"
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, int]] = []
+
+    def increment(self, name: str, label: str, count: int = 1) -> None:
+        self.calls.append((name, label, count))
+
+
+class TestPricing:
+    def test_input_cost(self) -> None:
+        """$0.30 за миллион — миллион токенов стоит 300 000 микродолларов."""
+        assert cost_micro_usd(MODEL, input_tokens=1_000_000) == 300_000
+
+    def test_cache_read_is_ten_times_cheaper(self) -> None:
+        plain = cost_micro_usd(MODEL, input_tokens=1_000_000)
+        cached = cost_micro_usd(MODEL, cache_read_tokens=1_000_000)
+
+        assert plain == pytest.approx(cached * 10, rel=0.01)
+
+    def test_cache_write_barely_costs_more_than_input(self) -> None:
+        """Промах по кэшу должен быть почти бесплатным, иначе включать рискованно."""
+        plain = cost_micro_usd(MODEL, input_tokens=1_000_000)
+        written = cost_micro_usd(MODEL, cache_write_tokens=1_000_000)
+
+        assert written / plain < 1.05
+
+    def test_unknown_model_costs_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Неизвестная цена — ноль, а не выдуманное число."""
+        monkeypatch.setattr(pricing, "_unknown_reported", set())
+
+        assert cost_micro_usd("who/knows", input_tokens=1_000_000) == 0
+
+    def test_parts_add_up(self) -> None:
+        total = cost_micro_usd(MODEL, input_tokens=1000, output_tokens=1000, cache_read_tokens=1000)
+        parts = (
+            cost_micro_usd(MODEL, input_tokens=1000)
+            + cost_micro_usd(MODEL, output_tokens=1000)
+            + cost_micro_usd(MODEL, cache_read_tokens=1000)
+        )
+
+        assert total == pytest.approx(parts, abs=2)
+
+    @pytest.mark.parametrize("model", sorted(PRICES))
+    def test_every_price_is_positive(self, model: str) -> None:
+        price = PRICES[model]
+
+        assert min(price.input, price.output, price.cache_read, price.cache_write) > 0
+
+
+class TestCounters:
+    def test_tokens_recorded_by_kind(self) -> None:
+        store = FakeStore()
+        service = PrometheusObservabilityService(store)
+
+        service.observe_llm_tokens(TokenKind.CACHE_READ, 3311)
+
+        assert store.calls == [(COUNTER_LLM_TOKENS, "cache_read", 3311)]
+
+    def test_cost_recorded_by_model(self) -> None:
+        store = FakeStore()
+        service = PrometheusObservabilityService(store)
+
+        service.observe_llm_cost(MODEL, 1234)
+
+        assert store.calls == [(COUNTER_LLM_COST_MICRO, MODEL, 1234)]
+
+    @pytest.mark.parametrize("value", [0, -5])
+    def test_nothing_recorded_for_empty_usage(self, value: int) -> None:
+        """Нули засоряют метки, а отрицательные значения ломают накопление."""
+        store = FakeStore()
+        service = PrometheusObservabilityService(store)
+
+        service.observe_llm_tokens(TokenKind.INPUT, value)
+        service.observe_llm_cost(MODEL, value)
+
+        assert store.calls == []
+
+
+class TestCachePoint:
+    def test_marker_goes_before_the_text(self) -> None:
+        """Метка после текста кэширует и сам текст — попаданий тогда не будет."""
+        import inspect
+
+        from app.infrastructure.extractors import vacancy_extractor
+
+        source = inspect.getsource(vacancy_extractor.GoogleVacancyLLMExtractor.parse_vacancy)
+        marker = source.index("CachePoint()")
+        text = source.index("Проанализируй текст")
+
+        assert marker < text
+
+    def test_resume_parsing_has_no_marker(self) -> None:
+        """Резюме грузят единицы раз в месяц: кэш протухнет, а запись оплатится."""
+        import inspect
+
+        from app.infrastructure.parsers import pdf_parser
+
+        assert "CachePoint" not in inspect.getsource(pdf_parser)
+
+    def test_marker_is_the_pydantic_ai_one(self) -> None:
+        assert CachePoint().ttl == "5m"


### PR DESCRIPTION
## Зачем

Разбор вакансий стоит ~$8.28 в месяц. Из 3825 входных токенов каждого вызова 3311 — это неизменные системный промпт и JSON-схема, то есть **87% входа одинаковы всегда**.

Gemini умеет кэшировать такой префикс, но через OpenRouter не включает это сам — нужна явная метка в запросе. До сих пор её не было, и мы платили полную цену за каждый токен.

## Что сделано

**Метка кэша** в классификаторе вакансий. Стоит первой, чтобы под кэш ушли промпт и схема, а текст вакансии остался снаружи — он каждый раз новый.

Разбор резюме намеренно не трогали: 6 загрузок за всю историю против TTL в пять минут, кэш там не сработает ни разу, а запись оплатится. Есть тест, который следит, чтобы метку туда не добавили.

**Учёт расхода.** Провайдер сам сообщает в ответе, сколько токенов прочитано из кэша и сколько записано. Пишем это в счётчики и переводим в деньги по таблице цен. Счётчики переживают перезапуск, как остальные.

**Раздел «Расходы на модель»** в дашборде pipeline: потрачено всего, за сутки, доля попаданий в кэш, токены по видам и график расхода.

## Экономика

Запись в кэш дороже обычного входа на 2%, чтение — дешевле в десять раз. Точка безубыточности: **2.5% попаданий**.

| Попаданий | $/мес |
|---|---|
| 0% | 8.41 |
| 25% | 7.16 |
| 50% | 5.91 |
| 100% | 3.42 |

TTL у Gemini пять минут и не продлевается, а вызовы идут в среднем раз в 8 минут — часть промахнётся. Предсказать долю нельзя, поэтому и добавлены метрики.

## Как проверять после выкатки

Смотреть на панель **«Попаданий в кэш»**. Ниже 2.5% — не окупается, метку стоит снять. Осмысленное значение появится через сутки.

Проверено локально: вызов с попаданием стоит 629 микродолларов против 1523 без кэша.

## Риски

Прайс-таблица в коде: при смене модели её надо дополнить, иначе расход считается нулём (в лог уходит предупреждение). Поведение разбора не меняется — метка кэша на результат не влияет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)